### PR TITLE
feat(Options): Add option to keep going after failed package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "If enabled packages are build and pushed"
     default: true
     required: true
+  dont_fail:
+    description: "If enabled, packages that fail in their build will not"
+    default: false
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -32,3 +36,4 @@ runs:
         INPUTS_ATTIC_TOKEN: ${{ inputs.attic_token }}
         INPUTS_INSTALL_DEPS: true
         INPUTS_LITTLE_SPACE: true
+        INPUTS_DONT_FAIL: ${{ inputs.dont_fail }}

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,11 @@ build_packages() {
         if [[ "$PACKAGES" != "" ]]; then
           for PACKAGE in $PACKAGES; do
             echo Building $ARCH.$PACKAGE
-            nix build --accept-flake-config .\#packages.$ARCH.$PACKAGE --max-jobs 2
+            if [[ ($INPUTS_DONT_FAIL == 'true') || ($INPUTS_DONT_FAIL == '') ]]; then
+              nix build --accept-flake-config .\#packages.$ARCH.$PACKAGE --max-jobs 2 --keep-going
+            else
+              nix build --accept-flake-config .\#packages.$ARCH.$PACKAGE --max-jobs 2
+            fi
             if [ $? -eq 0 ]; then
               echo $ARCH.$PACKAGE was build!
               push
@@ -81,7 +85,11 @@ build_systems() {
       SYSTEM_ARCH=$(nix repl <<< ":lf ." <<< ":p nixosConfigurations.$SYSTEM.pkgs.system" 2> /dev/null)
       if [[ "$SYSTEM_ARCH" =~ $SUPPORTED_ARCHS_REGEX ]]; then
         echo Building $SYSTEM ...
-        nix build --accept-flake-config .\#nixosConfigurations.$SYSTEM.config.system.build.toplevel --max-jobs 2
+        if [[ ($INPUTS_DONT_FAIL == 'true') || ($INPUTS_DONT_FAIL == '') ]]; then
+          nix build --accept-flake-config .\#nixosConfigurations.$SYSTEM.config.system.build.toplevel --max-jobs 2 --keep-going
+        else
+          nix build --accept-flake-config .\#nixosConfigurations.$SYSTEM.config.system.build.toplevel --max-jobs 2
+        fi
         if [ $? -eq 0 ]; then
           echo $SYSTEM was build!
           push


### PR DESCRIPTION
This adds an option to set the --keep-going argument for the Nix Build Command to prevent failure of the whole script if only one Package fails (For example the f1-multiviewer package always fails when run in the action)